### PR TITLE
Update column text subheader block size.

### DIFF
--- a/sas7bdat.go
+++ b/sas7bdat.go
@@ -673,7 +673,8 @@ func (sas *SAS7BDAT) chunkToSeries() []*Series {
 					miss[i] = true
 				}
 			}
-			if sas.ConvertDates && (sas.ColumnFormats[j] == "MMDDYY") {
+			if sas.ConvertDates && (sas.ColumnFormats[j] == "MMDDYY" ||
+				sas.ColumnFormats[j] == "DATE") {
 				tvec := toDate(vec)
 				rslt[j], _ = NewSeries(name, tvec, miss)
 			} else if sas.ConvertDates && (sas.ColumnFormats[j] == "DATETIME") {

--- a/sas7bdat.go
+++ b/sas7bdat.go
@@ -1281,16 +1281,14 @@ func (sas *SAS7BDAT) processColumnsizeSubheader(offset, length int) error {
 func (sas *SAS7BDAT) processColumnTextSubheader(offset, length int) error {
 
 	offset += sas.properties.intLength
-	text_block_size, err := sas.readInt(offset, text_block_size_length)
-	if err != nil {
-		return fmt.Errorf("Cannot read text block size for column names.")
-	}
+	// column text subheader block starts after the signature
+	textBlockSize := length - sas.properties.intLength
 
-	err = sas.readBytes(offset, text_block_size)
+	err := sas.readBytes(offset, textBlockSize)
 	if err != nil {
 		return fmt.Errorf("Cannot read column names strings.")
 	}
-	sas.columnNamesStrings = append(sas.columnNamesStrings, string(sas.buf[0:text_block_size]))
+	sas.columnNamesStrings = append(sas.columnNamesStrings, string(sas.buf[0:textBlockSize]))
 
 	if len(sas.columnNamesStrings) == 1 {
 		column_name := sas.columnNamesStrings[0]


### PR DESCRIPTION
The column text subheader block size refers to the size of the block which contains compression, creator, name, label, and format information (size = QL - 16|20). For indexing purposes, the text block starts immediately after the subheader's signature.

Previously, we were reading from the correct offset (immediately after the signature) but were reading the column text subheader block size number of bytes. Thus, labels for the last column in the dataset were being cut off as were missing n bytes at the end where n is equal to the number of bytes in between the subheader signature and the start of compression data.