### PR TITLE
Remove align correction for "mix" pages.

### DIFF
--- a/sas7bdat.go
+++ b/sas7bdat.go
@@ -789,13 +789,12 @@ func (sas *SAS7BDAT) readline() (error, bool) {
 			}
 			return nil, false
 		} else if sas.isPageMixType(sas.currentPageType) {
-			align_correction := bit_offset + subheader_pointers_offset +
+			offset := bit_offset + subheader_pointers_offset +
 				sas.currentPageSubheadersCount*subheaderPointerLength
-			align_correction = align_correction % 8
-			offset := bit_offset + align_correction
-			offset += subheader_pointers_offset
-			offset += sas.currentPageSubheadersCount * subheaderPointerLength
-			offset += sas.currentRowOnPageIndex * sas.properties.rowLength
+			align_correction := offset % 8
+			if sas.U64 {
+				offset += align_correction
+			}
 			err := sas.processByteArrayWithData(offset, sas.properties.rowLength)
 			if err != nil {
 				return err, false


### PR DESCRIPTION
The offset for binary data was being computed incorrectly for "mix" pages when the file is x86 format. I tested this fix on over five files and replicated the bug with Matt's original R code (https://github.com/BioStatMatt/sas7bdat). I have reason to believe the document (https://cran.r-project.org/web/packages/sas7bdat/vignettes/sas7bdat.pdf) needs amendment to account for U64 in calculating the modulo offset.