### PR TITLE
if needed data spans onto the next page, read it in before panic

### DIFF
--- a/sas7bdat.go
+++ b/sas7bdat.go
@@ -1205,6 +1205,14 @@ func (sas *SAS7BDAT) processByteArrayWithData(offset, length int) error {
 			return err
 		}
 	} else {
+		if offset+length > len(sas.cachedPage) {
+			oldPage := sas.cachedPage
+			err, ok := sas.readNextPage()
+			if err != nil || !ok {
+				return fmt.Errorf("error reading next page - %w", err)
+			}
+			sas.cachedPage = append(oldPage, sas.cachedPage...)
+		}
 		source = sas.cachedPage[offset : offset+length]
 	}
 


### PR DESCRIPTION
Seems to fix #19 